### PR TITLE
Fixed .pop() context reference bug

### DIFF
--- a/lib/features/player/modules/chapters.dart
+++ b/lib/features/player/modules/chapters.dart
@@ -4,7 +4,6 @@ import 'package:abs_flutter/util/helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
 class Chapters extends ConsumerWidget {
   final List<dynamic> chapters;
@@ -84,7 +83,7 @@ class Chapters extends ConsumerWidget {
               PlatformDialogAction(
                 child: PlatformText(S.of(context).close),
                 onPressed: () {
-                  context.pop();
+                  Navigator.of(context, rootNavigator: true).pop();
                 },
               ),
             ],


### PR DESCRIPTION
Fixed a bug where .pop() was called on an incorrect context, ensuring it now references the correct context.

Copilot summary:
This pull request includes changes to the `lib/features/player/modules/chapters.dart` file to update the import statements and modify the method used for navigation.

Navigation method update:

* [`lib/features/player/modules/chapters.dart`](diffhunk://#diff-f934a6ea8ca84044efd3e5b05f35061e8c0b826bf9c9a8cec4a6f6a8bb7d7ce3L87-R86): Changed the navigation method from `context.pop()` to `Navigator.of(context, rootNavigator: true).pop()` to ensure the dialog is closed using the root navigator.

Import statement update:

* [`lib/features/player/modules/chapters.dart`](diffhunk://#diff-f934a6ea8ca84044efd3e5b05f35061e8c0b826bf9c9a8cec4a6f6a8bb7d7ce3L7): Removed the unused import statement `import 'package:go_router/go_router.dart';` to clean up the code.