### PR TITLE
Fixed wrong filtering for Podcasts

### DIFF
--- a/lib/features/library/item/podcast/episode_filter_sort.dart
+++ b/lib/features/library/item/podcast/episode_filter_sort.dart
@@ -9,14 +9,14 @@ List<Episode> filterEpisodes(
     case 'Incomplete':
       return episodes.where((episode) {
         final progress =
-            progresses.progress?['${episode.libraryItemId}${episode.id ?? ''}'];
-        return progress != null && progress.progress! < 1.0;
+        progresses.progress?['${episode.libraryItemId}${episode.id ?? ''}'];
+        return progress == null || progress.progress! < .99;
       }).toList();
     case 'Complete':
       return episodes.where((episode) {
         final progress =
             progresses.progress?['${episode.libraryItemId}${episode.id ?? ''}'];
-        return progress != null && progress.progress! == 1.0;
+        return progress != null && progress.progress! >= .99;
       }).toList();
     case 'In Progress':
       return episodes.where((episode) {
@@ -24,7 +24,7 @@ List<Episode> filterEpisodes(
             progresses.progress?['${episode.libraryItemId}${episode.id ?? ''}'];
         return progress != null &&
             progress.progress! > 0 &&
-            progress.progress! < 1.0;
+            progress.progress! < .99;
       }).toList();
     default:
       return episodes;


### PR DESCRIPTION
closes #90 

Filtering should now work properly and handle more cases, as all podcasts with 99% completion are considered finished. This accounts for items with a 'finished' progress value as unprecise as 0.9996, for example.
