### PR TITLE
Added setting to disable Vibrations

### DIFF
--- a/lib/features/settings/components/settings_tile_wrapper.dart
+++ b/lib/features/settings/components/settings_tile_wrapper.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+import 'package:settings_ui/settings_ui.dart';
+
+class SettingsTileWrapper extends AbstractSettingsTile {
+  final Widget child;
+  const SettingsTileWrapper({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return child;
+  }
+}

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -186,6 +186,8 @@ class MessageLookup extends MessageLookupByLibrary {
         "descending": MessageLookupByLibrary.simpleMessage("Descending"),
         "description": MessageLookupByLibrary.simpleMessage("Description"),
         "deviceInfo": m22,
+        "disableVibration":
+            MessageLookupByLibrary.simpleMessage("Disable Vibration"),
         "disabled": MessageLookupByLibrary.simpleMessage("Disabled"),
         "discover": MessageLookupByLibrary.simpleMessage("Discover"),
         "domainOrIp": MessageLookupByLibrary.simpleMessage("Domain or IP"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -2562,6 +2562,16 @@ class S {
       args: [],
     );
   }
+
+  /// `Disable Vibration`
+  String get disableVibration {
+    return Intl.message(
+      'Disable Vibration',
+      name: 'disableVibration',
+      desc: '',
+      args: [],
+    );
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<S> {

--- a/lib/globals.dart
+++ b/lib/globals.dart
@@ -53,6 +53,7 @@ final Map<String, dynamic> defaultSettings = {
   Constants.DOWNLOAD_PATH: null,
   Constants.SORT_SERIES_ASC: false,
   Constants.SHOW_MEDIA_TYPE: true,
+  Constants.DISABEL_VIBRATION: false,
 };
 
 final Map<String, String> supportedLocales = {

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -751,5 +751,6 @@
   "waitingForDownload": "Waiting for download to start",
   "@waitingForDownload": {},
   "year": "Year",
-  "@year": {}
+  "@year": {},
+  "disableVibration": "Disable Vibration"
 }

--- a/lib/provider/sleep_timer_provider.dart
+++ b/lib/provider/sleep_timer_provider.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
-import 'package:abs_flutter/provider/log_provider.dart';
 
+import 'package:abs_flutter/provider/log_provider.dart';
 import 'package:abs_flutter/provider/player_provider.dart';
 import 'package:abs_flutter/provider/player_status_provider.dart';
 import 'package:abs_flutter/provider/settings_provider.dart';
@@ -34,12 +34,16 @@ class TimerNotifier extends StateNotifier<double?> {
           name: 'SleepTimer');
       if (_duration != null && !_isPaused) {
         updateTimer(_duration!);
-        final hasVibration = await Vibration.hasVibrator();
-        final hasAmplitudeControl = await Vibration.hasAmplitudeControl();
-        if (hasAmplitudeControl != null && hasAmplitudeControl) {
-          Vibration.vibrate(duration: 250, intensities: [100]);
-        } else if (hasVibration != null && hasVibration) {
-          Vibration.vibrate();
+        final settings = ref
+            .read(specificKeysSettingsProvider([Constants.DISABEL_VIBRATION]));
+        if (!settings[Constants.DISABEL_VIBRATION]) {
+          final hasVibration = await Vibration.hasVibrator();
+          final hasAmplitudeControl = await Vibration.hasAmplitudeControl();
+          if (hasAmplitudeControl != null && hasAmplitudeControl) {
+            Vibration.vibrate(duration: 250, intensities: [100]);
+          } else if (hasVibration != null && hasVibration) {
+            Vibration.vibrate();
+          }
         }
       }
     });
@@ -69,7 +73,8 @@ class TimerNotifier extends StateNotifier<double?> {
 
   void _startTimer() {
     _timer?.cancel(); // Cancel any existing timer before starting a new one
-    final settings = ref.read(settingsProvider);
+    final settings =
+        ref.read(specificKeysSettingsProvider([Constants.SHAKE_RESET_TIMER]));
     if (settings[Constants.SHAKE_RESET_TIMER]) _shakeHandler.start();
 
     // When the timer starts to volume down the player

--- a/lib/util/constants.dart
+++ b/lib/util/constants.dart
@@ -22,6 +22,7 @@ class Constants {
   static const String DOWNLOAD_PATH = 'downloadPath';
   static const String SORT_SERIES_ASC = 'sortSeriesAsc';
   static const String SHOW_MEDIA_TYPE = 'showMediaType';
+  static const String DISABEL_VIBRATION = 'disableVibration';
 
   static const String BOOK = 'book';
   static const String PODCAST = 'podcast';


### PR DESCRIPTION
closes #105 

This pull request introduces a new feature to disable vibration and includes several related changes across multiple files. The most important changes include adding the `SettingsTileWrapper` class, updating the `PlatformSettings` to include the new setting, and modifying the `TimerNotifier` to respect the new vibration setting.

New feature implementation:

* [`lib/features/settings/components/settings_tile_wrapper.dart`](diffhunk://#diff-6d73a63b1300d07f02910ef151c3dcab70c63258d0866af5e697331dfcdfd575R1-R12): Added a new `SettingsTileWrapper` class to wrap settings tiles.
* [`lib/features/settings/platform_settings.dart`](diffhunk://#diff-2bcdc33c2472696976e52815a55abd09a93f14954a1f0d4a0ca6b897e1463c7cR23-R35): Updated the `PlatformSettings` to include the `SHAKE_RESET_TIMER` setting and added a conditional check for the vibration setting. [[1]](diffhunk://#diff-2bcdc33c2472696976e52815a55abd09a93f14954a1f0d4a0ca6b897e1463c7cR23-R35) [[2]](diffhunk://#diff-2bcdc33c2472696976e52815a55abd09a93f14954a1f0d4a0ca6b897e1463c7cR153-R175)

Settings and constants updates:

* [`lib/globals.dart`](diffhunk://#diff-eb60662e204ec9eaebd9e2943b978123596773a88058deeecc5f913118e9a756R56): Added `Constants.DISABEL_VIBRATION` to the default settings.
* [`lib/l10n/intl_en.arb`](diffhunk://#diff-d38a1072799c0e0b8936fb54ea8bcc732c76241afed954d025815eb8369aad32L754-R755): Added the "Disable Vibration" string to the localization file.
* [`lib/util/constants.dart`](diffhunk://#diff-6289dc94a5bccb777975b6c22af109385e9fe9e14f386867c2d5c666af629a01R25): Added `DISABEL_VIBRATION` constant.

Provider modifications:

* [`lib/provider/sleep_timer_provider.dart`](diffhunk://#diff-423e63eee3b7ef2be93b5e9f2f2c68bd43799f7fec5aa7b1799be4edbc5d14b2R37-R39): Updated `TimerNotifier` to check the `DISABEL_VIBRATION` setting before triggering vibration. [[1]](diffhunk://#diff-423e63eee3b7ef2be93b5e9f2f2c68bd43799f7fec5aa7b1799be4edbc5d14b2R37-R39) [[2]](diffhunk://#diff-423e63eee3b7ef2be93b5e9f2f2c68bd43799f7fec5aa7b1799be4edbc5d14b2R48) [[3]](diffhunk://#diff-423e63eee3b7ef2be93b5e9f2f2c68bd43799f7fec5aa7b1799be4edbc5d14b2L72-R77)