### PR TITLE
Persistent Media Controls

### DIFF
--- a/lib/features/player/modules/speed_control.dart
+++ b/lib/features/player/modules/speed_control.dart
@@ -1,9 +1,12 @@
 import 'package:abs_flutter/generated/l10n.dart';
 import 'package:abs_flutter/provider/player_provider.dart';
+import 'package:abs_flutter/provider/user_provider.dart';
+import 'package:abs_flutter/util/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class SpeedControl extends StatelessWidget {
+class SpeedControl extends ConsumerWidget {
   final PlayerProvider player;
   final Stream<double> speedStream;
   final double? size;
@@ -22,10 +25,11 @@ class SpeedControl extends StatelessWidget {
   };
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return PlatformPopupMenu(
       options: speedOptions.entries
-          .map((entry) => _buildSpeedOption(entry.key, entry.value, context))
+          .map((entry) =>
+              _buildSpeedOption(entry.key, entry.value, context, ref))
           .toList(),
       icon: Tooltip(
         message: S.of(context).playbackSpeed,
@@ -52,10 +56,26 @@ class SpeedControl extends StatelessWidget {
   }
 
   PopupMenuOption _buildSpeedOption(
-      String key, double value, BuildContext context) {
+      String key, double value, BuildContext context, WidgetRef ref) {
     return PopupMenuOption(
         label: key,
         onTap: (option) {
+          final users = ref.read(usersProvider);
+          final userIndex = ref.read(selectedUserProvider);
+          final user = users[userIndex];
+
+          final updatedUser = user.copyWith(
+            setting: user.setting!.copyWith(
+              settings: {
+                ...user.setting!.settings,
+                Constants.PLAYBACK_SPEED: value
+              },
+            ),
+          );
+
+          ref
+              .read(usersProvider.notifier)
+              .updateUserAtIndex(userIndex, updatedUser);
           player.audioService.player.setSpeed(value);
         });
   }

--- a/lib/features/player/modules/volume.dart
+++ b/lib/features/player/modules/volume.dart
@@ -1,8 +1,11 @@
 import 'package:abs_flutter/provider/player_provider.dart';
+import 'package:abs_flutter/provider/user_provider.dart';
+import 'package:abs_flutter/util/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-class Volume extends StatefulWidget {
+class Volume extends ConsumerStatefulWidget {
   const Volume({
     super.key,
     required this.volumeStream,
@@ -18,7 +21,7 @@ class Volume extends StatefulWidget {
   _VolumeState createState() => _VolumeState();
 }
 
-class _VolumeState extends State<Volume> {
+class _VolumeState extends ConsumerState<Volume> {
   final GlobalKey _buttonKey = GlobalKey();
   OverlayEntry? _overlayEntry;
 
@@ -74,6 +77,24 @@ class _VolumeState extends State<Volume> {
                           value: snapshot.data ?? 0.0,
                           onChanged: (double value) {
                             widget.player.audioService.setVolume(value);
+                          },
+                          onChangeEnd: (double value) {
+                            final users = ref.read(usersProvider);
+                            final userIndex = ref.read(selectedUserProvider);
+                            final user = users[userIndex];
+
+                            final updatedUser = user.copyWith(
+                              setting: user.setting!.copyWith(
+                                settings: {
+                                  ...user.setting!.settings,
+                                  Constants.VOLUME: value
+                                },
+                              ),
+                            );
+
+                            ref
+                                .read(usersProvider.notifier)
+                                .updateUserAtIndex(userIndex, updatedUser);
                           },
                         ),
                       ),

--- a/lib/globals.dart
+++ b/lib/globals.dart
@@ -54,6 +54,8 @@ final Map<String, dynamic> defaultSettings = {
   Constants.SORT_SERIES_ASC: false,
   Constants.SHOW_MEDIA_TYPE: true,
   Constants.DISABEL_VIBRATION: false,
+  Constants.VOLUME: 1.0,
+  Constants.PLAYBACK_SPEED: 1.0,
 };
 
 final Map<String, String> supportedLocales = {

--- a/lib/util/abs_audio_handler.dart
+++ b/lib/util/abs_audio_handler.dart
@@ -14,6 +14,7 @@ import 'package:abs_flutter/provider/queue_provider.dart';
 import 'package:abs_flutter/provider/session_provider.dart';
 import 'package:abs_flutter/provider/settings_provider.dart';
 import 'package:abs_flutter/provider/sleep_timer_provider.dart';
+import 'package:abs_flutter/util/constants.dart';
 import 'package:abs_flutter/util/tray_menu_handler.dart';
 import 'package:audio_service/audio_service.dart';
 import 'package:flutter/foundation.dart';
@@ -128,6 +129,10 @@ class AbsAudioHandler extends BaseAudioHandler with QueueHandler, SeekHandler {
     mediaItem.add(item);
 
     await _player.setAudioSource(source);
+
+    setSpeed(_settingsProvider?[Constants.PLAYBACK_SPEED] ?? 1.0);
+
+    setVolume(_settingsProvider?[Constants.VOLUME] ?? 1.0);
 
     await play();
   }

--- a/lib/util/constants.dart
+++ b/lib/util/constants.dart
@@ -23,6 +23,8 @@ class Constants {
   static const String SORT_SERIES_ASC = 'sortSeriesAsc';
   static const String SHOW_MEDIA_TYPE = 'showMediaType';
   static const String DISABEL_VIBRATION = 'disableVibration';
+  static const String VOLUME = 'volume';
+  static const String PLAYBACK_SPEED = 'playbackSpeed';
 
   static const String BOOK = 'book';
   static const String PODCAST = 'podcast';


### PR DESCRIPTION
Implements persistent settings for Volume and Playback Speed.

Resolves issue (closes #99).

Copilot summary:
This pull request includes several changes to integrate user settings for playback speed and volume into the player module. The most important changes include converting `SpeedControl` and `Volume` components to use `ConsumerWidget` and `ConsumerStatefulWidget`, updating user settings when playback speed or volume changes, and adding new constants for these settings.

### Integration of User Settings:

* [`lib/features/player/modules/speed_control.dart`](diffhunk://#diff-51628f196621a28572bd22d05295773b02ac1f7b3847ccc4508f9d07ca079313R3-R9): Converted `SpeedControl` from `StatelessWidget` to `ConsumerWidget`, allowing it to read and update user settings using `WidgetRef`. Updated the `build` and `_buildSpeedOption` methods to handle user settings for playback speed. [[1]](diffhunk://#diff-51628f196621a28572bd22d05295773b02ac1f7b3847ccc4508f9d07ca079313R3-R9) [[2]](diffhunk://#diff-51628f196621a28572bd22d05295773b02ac1f7b3847ccc4508f9d07ca079313L25-R32) [[3]](diffhunk://#diff-51628f196621a28572bd22d05295773b02ac1f7b3847ccc4508f9d07ca079313L55-R78)

* [`lib/features/player/modules/volume.dart`](diffhunk://#diff-93724652d617f74e61e5c07e9fb5869ff770a6d87366fe89c44c350345f873caR2-R8): Converted `Volume` from `StatefulWidget` to `ConsumerStatefulWidget`, allowing it to read and update user settings using `WidgetRef`. Added logic in the `onChangeEnd` callback to update user settings for volume. [[1]](diffhunk://#diff-93724652d617f74e61e5c07e9fb5869ff770a6d87366fe89c44c350345f873caR2-R8) [[2]](diffhunk://#diff-93724652d617f74e61e5c07e9fb5869ff770a6d87366fe89c44c350345f873caL21-R24) [[3]](diffhunk://#diff-93724652d617f74e61e5c07e9fb5869ff770a6d87366fe89c44c350345f873caR81-R98)

### Addition of New Constants:

* [`lib/globals.dart`](diffhunk://#diff-eb60662e204ec9eaebd9e2943b978123596773a88058deeecc5f913118e9a756R57-R58): Added default values for `Constants.VOLUME` and `Constants.PLAYBACK_SPEED` in the `defaultSettings` map.

* [`lib/util/constants.dart`](diffhunk://#diff-6289dc94a5bccb777975b6c22af109385e9fe9e14f386867c2d5c666af629a01R26-R27): Added new constants `VOLUME` and `PLAYBACK_SPEED` to the `Constants` class.

### Updates to Audio Handler:

* [`lib/util/abs_audio_handler.dart`](diffhunk://#diff-f56be96564cca4cdd4e7480fcaad1dec682d73d40a542e4ad7d46d03adff25e9R17): Imported `Constants` and updated the `AbsAudioHandler` class to set playback speed and volume based on user settings when initializing the audio source. [[1]](diffhunk://#diff-f56be96564cca4cdd4e7480fcaad1dec682d73d40a542e4ad7d46d03adff25e9R17) [[2]](diffhunk://#diff-f56be96564cca4cdd4e7480fcaad1dec682d73d40a542e4ad7d46d03adff25e9R133-R136)