### PR TITLE
fixed stats not loading and sync now contains more data

### DIFF
--- a/lib/api/library_items/playback_session.dart
+++ b/lib/api/library_items/playback_session.dart
@@ -17,7 +17,7 @@ class PlaybackSession with _$PlaybackSession {
     @JsonKey(name: "libraryItemId") required String libraryItemId,
     @JsonKey(name: "episodeId") String? episodeId,
     @JsonKey(name: "mediaType") String? mediaType,
-    @JsonKey(name: "mediaMetadata") required Metadata mediaMetadata,
+    @JsonKey(name: "mediaMetadata") Metadata? mediaMetadata,
     @JsonKey(name: "chapters") List<Chapter>? chapters,
     @JsonKey(name: "displayTitle") String? displayTitle,
     @JsonKey(name: "displayAuthor") String? displayAuthor,

--- a/lib/api/library_items/playback_session.freezed.dart
+++ b/lib/api/library_items/playback_session.freezed.dart
@@ -33,7 +33,7 @@ mixin _$PlaybackSession {
   @JsonKey(name: "mediaType")
   String? get mediaType => throw _privateConstructorUsedError;
   @JsonKey(name: "mediaMetadata")
-  Metadata get mediaMetadata => throw _privateConstructorUsedError;
+  Metadata? get mediaMetadata => throw _privateConstructorUsedError;
   @JsonKey(name: "chapters")
   List<Chapter>? get chapters => throw _privateConstructorUsedError;
   @JsonKey(name: "displayTitle")
@@ -94,7 +94,7 @@ abstract class $PlaybackSessionCopyWith<$Res> {
       @JsonKey(name: "libraryItemId") String libraryItemId,
       @JsonKey(name: "episodeId") String? episodeId,
       @JsonKey(name: "mediaType") String? mediaType,
-      @JsonKey(name: "mediaMetadata") Metadata mediaMetadata,
+      @JsonKey(name: "mediaMetadata") Metadata? mediaMetadata,
       @JsonKey(name: "chapters") List<Chapter>? chapters,
       @JsonKey(name: "displayTitle") String? displayTitle,
       @JsonKey(name: "displayAuthor") String? displayAuthor,
@@ -114,7 +114,7 @@ abstract class $PlaybackSessionCopyWith<$Res> {
       @JsonKey(name: "audioTracks") List<AudioTrack>? audioTracks,
       @JsonKey(name: "libraryItem") LibraryItem? libraryItem});
 
-  $MetadataCopyWith<$Res> get mediaMetadata;
+  $MetadataCopyWith<$Res>? get mediaMetadata;
   $DeviceInfoCopyWith<$Res>? get deviceInfo;
   $LibraryItemCopyWith<$Res>? get libraryItem;
 }
@@ -140,7 +140,7 @@ class _$PlaybackSessionCopyWithImpl<$Res, $Val extends PlaybackSession>
     Object? libraryItemId = null,
     Object? episodeId = freezed,
     Object? mediaType = freezed,
-    Object? mediaMetadata = null,
+    Object? mediaMetadata = freezed,
     Object? chapters = freezed,
     Object? displayTitle = freezed,
     Object? displayAuthor = freezed,
@@ -185,10 +185,10 @@ class _$PlaybackSessionCopyWithImpl<$Res, $Val extends PlaybackSession>
           ? _value.mediaType
           : mediaType // ignore: cast_nullable_to_non_nullable
               as String?,
-      mediaMetadata: null == mediaMetadata
+      mediaMetadata: freezed == mediaMetadata
           ? _value.mediaMetadata
           : mediaMetadata // ignore: cast_nullable_to_non_nullable
-              as Metadata,
+              as Metadata?,
       chapters: freezed == chapters
           ? _value.chapters
           : chapters // ignore: cast_nullable_to_non_nullable
@@ -268,8 +268,12 @@ class _$PlaybackSessionCopyWithImpl<$Res, $Val extends PlaybackSession>
   /// with the given fields replaced by the non-null parameter values.
   @override
   @pragma('vm:prefer-inline')
-  $MetadataCopyWith<$Res> get mediaMetadata {
-    return $MetadataCopyWith<$Res>(_value.mediaMetadata, (value) {
+  $MetadataCopyWith<$Res>? get mediaMetadata {
+    if (_value.mediaMetadata == null) {
+      return null;
+    }
+
+    return $MetadataCopyWith<$Res>(_value.mediaMetadata!, (value) {
       return _then(_value.copyWith(mediaMetadata: value) as $Val);
     });
   }
@@ -318,7 +322,7 @@ abstract class _$$PlaybackSessionImplCopyWith<$Res>
       @JsonKey(name: "libraryItemId") String libraryItemId,
       @JsonKey(name: "episodeId") String? episodeId,
       @JsonKey(name: "mediaType") String? mediaType,
-      @JsonKey(name: "mediaMetadata") Metadata mediaMetadata,
+      @JsonKey(name: "mediaMetadata") Metadata? mediaMetadata,
       @JsonKey(name: "chapters") List<Chapter>? chapters,
       @JsonKey(name: "displayTitle") String? displayTitle,
       @JsonKey(name: "displayAuthor") String? displayAuthor,
@@ -339,7 +343,7 @@ abstract class _$$PlaybackSessionImplCopyWith<$Res>
       @JsonKey(name: "libraryItem") LibraryItem? libraryItem});
 
   @override
-  $MetadataCopyWith<$Res> get mediaMetadata;
+  $MetadataCopyWith<$Res>? get mediaMetadata;
   @override
   $DeviceInfoCopyWith<$Res>? get deviceInfo;
   @override
@@ -365,7 +369,7 @@ class __$$PlaybackSessionImplCopyWithImpl<$Res>
     Object? libraryItemId = null,
     Object? episodeId = freezed,
     Object? mediaType = freezed,
-    Object? mediaMetadata = null,
+    Object? mediaMetadata = freezed,
     Object? chapters = freezed,
     Object? displayTitle = freezed,
     Object? displayAuthor = freezed,
@@ -410,10 +414,10 @@ class __$$PlaybackSessionImplCopyWithImpl<$Res>
           ? _value.mediaType
           : mediaType // ignore: cast_nullable_to_non_nullable
               as String?,
-      mediaMetadata: null == mediaMetadata
+      mediaMetadata: freezed == mediaMetadata
           ? _value.mediaMetadata
           : mediaMetadata // ignore: cast_nullable_to_non_nullable
-              as Metadata,
+              as Metadata?,
       chapters: freezed == chapters
           ? _value._chapters
           : chapters // ignore: cast_nullable_to_non_nullable
@@ -500,7 +504,7 @@ class _$PlaybackSessionImpl implements _PlaybackSession {
       @JsonKey(name: "libraryItemId") required this.libraryItemId,
       @JsonKey(name: "episodeId") this.episodeId,
       @JsonKey(name: "mediaType") this.mediaType,
-      @JsonKey(name: "mediaMetadata") required this.mediaMetadata,
+      @JsonKey(name: "mediaMetadata") this.mediaMetadata,
       @JsonKey(name: "chapters") final List<Chapter>? chapters,
       @JsonKey(name: "displayTitle") this.displayTitle,
       @JsonKey(name: "displayAuthor") this.displayAuthor,
@@ -545,7 +549,7 @@ class _$PlaybackSessionImpl implements _PlaybackSession {
   final String? mediaType;
   @override
   @JsonKey(name: "mediaMetadata")
-  final Metadata mediaMetadata;
+  final Metadata? mediaMetadata;
   final List<Chapter>? _chapters;
   @override
   @JsonKey(name: "chapters")
@@ -731,7 +735,7 @@ abstract class _PlaybackSession implements PlaybackSession {
           @JsonKey(name: "libraryItemId") required final String libraryItemId,
           @JsonKey(name: "episodeId") final String? episodeId,
           @JsonKey(name: "mediaType") final String? mediaType,
-          @JsonKey(name: "mediaMetadata") required final Metadata mediaMetadata,
+          @JsonKey(name: "mediaMetadata") final Metadata? mediaMetadata,
           @JsonKey(name: "chapters") final List<Chapter>? chapters,
           @JsonKey(name: "displayTitle") final String? displayTitle,
           @JsonKey(name: "displayAuthor") final String? displayAuthor,
@@ -775,7 +779,7 @@ abstract class _PlaybackSession implements PlaybackSession {
   String? get mediaType;
   @override
   @JsonKey(name: "mediaMetadata")
-  Metadata get mediaMetadata;
+  Metadata? get mediaMetadata;
   @override
   @JsonKey(name: "chapters")
   List<Chapter>? get chapters;

--- a/lib/api/library_items/playback_session.g.dart
+++ b/lib/api/library_items/playback_session.g.dart
@@ -15,8 +15,9 @@ _$PlaybackSessionImpl _$$PlaybackSessionImplFromJson(
       libraryItemId: json['libraryItemId'] as String,
       episodeId: json['episodeId'] as String?,
       mediaType: json['mediaType'] as String?,
-      mediaMetadata:
-          Metadata.fromJson(json['mediaMetadata'] as Map<String, dynamic>),
+      mediaMetadata: json['mediaMetadata'] == null
+          ? null
+          : Metadata.fromJson(json['mediaMetadata'] as Map<String, dynamic>),
       chapters: (json['chapters'] as List<dynamic>?)
           ?.map((e) => Chapter.fromJson(e as Map<String, dynamic>))
           .toList(),

--- a/lib/provider/connection_provider.dart
+++ b/lib/provider/connection_provider.dart
@@ -242,6 +242,9 @@ class ConnectionNotifier extends StateNotifier<bool>
         bookItem['starttime'] = item.currentTime;
         bookItem['createdAt'] = item.createdAt?.millisecondsSinceEpoch;
         bookItem['updatedAt'] = item.updatedAt?.millisecondsSinceEpoch;
+        bookItem['mediaMetadata'] =
+            libraryItem.media?.bookMedia?.metadata.toJson() ??
+                libraryItem.media?.podcastMedia?.metadata.toJson();
         bookItem['deviceInfo'] = {
           'clientName': appName,
           'clientVersion': version,

--- a/lib/provider/session_provider.dart
+++ b/lib/provider/session_provider.dart
@@ -83,7 +83,7 @@ class PlaybackSessionNotifier
 
         _session = response;
 
-        if (_session!.data!.mediaMetadata.podcastMetadata != null) {
+        if (_session!.data!.mediaMetadata?.podcastMetadata != null) {
           _podcastSession(_session!.data!.libraryItemId,
               _session!.data!.episodeId!, _session!.data!);
         } else {
@@ -252,7 +252,7 @@ class PlaybackSessionNotifier
 
     MediaItem mediaItem = MediaItem(
         id: path!,
-        album: playback.mediaMetadata.podcastMetadata?.title,
+        album: playback.mediaMetadata?.podcastMetadata?.title,
         title: playback.displayTitle!,
         artist: playback.displayAuthor!,
         duration: Duration(
@@ -307,9 +307,10 @@ class PlaybackSessionNotifier
 
     MediaItem mediaItem = MediaItem(
         id: path!,
-        album: playback.mediaMetadata.bookMetadata?.series?.toList().join(', '),
+        album:
+            playback.mediaMetadata?.bookMetadata?.series?.toList().join(', '),
         title: playback.displayTitle!,
-        displaySubtitle: playback.mediaMetadata.bookMetadata?.subtitle,
+        displaySubtitle: playback.mediaMetadata?.bookMetadata?.subtitle,
         artist: playback.displayAuthor!,
         duration: Duration(
             seconds: playback.audioTracks!


### PR DESCRIPTION
This pull request modifies the `PlaybackSession` class and related files to make the `mediaMetadata` field nullable. This change ensures that the application can handle cases where `mediaMetadata` might not be available.

Key changes include:

### Changes to `PlaybackSession` class and related files:

* Made the `mediaMetadata` field nullable in the `PlaybackSession` class (`lib/api/library_items/playback_session.dart`).
* Updated the `_$PlaybackSession` mixin to reflect the nullable `mediaMetadata` field (`lib/api/library_items/playback_session.freezed.dart`). [[1]](diffhunk://#diff-7985d957fdcde5755b3896d66b58eda4da78182b3be43022a14d98702baf1150L36-R36) [[2]](diffhunk://#diff-7985d957fdcde5755b3896d66b58eda4da78182b3be43022a14d98702baf1150L97-R97) [[3]](diffhunk://#diff-7985d957fdcde5755b3896d66b58eda4da78182b3be43022a14d98702baf1150L117-R117) [[4]](diffhunk://#diff-7985d957fdcde5755b3896d66b58eda4da78182b3be43022a14d98702baf1150L143-R143) [[5]](diffhunk://#diff-7985d957fdcde5755b3896d66b58eda4da78182b3be43022a14d98702baf1150L188-R191) [[6]](diffhunk://#diff-7985d957fdcde5755b3896d66b58eda4da78182b3be43022a14d98702baf1150L271-R276) [[7]](diffhunk://#diff-7985d957fdcde5755b3896d66b58eda4da78182b3be43022a14d98702baf1150L321-R325) [[8]](diffhunk://#diff-7985d957fdcde5755b3896d66b58eda4da78182b3be43022a14d98702baf1150L342-R346) [[9]](diffhunk://#diff-7985d957fdcde5755b3896d66b58eda4da78182b3be43022a14d98702baf1150L368-R372) [[10]](diffhunk://#diff-7985d957fdcde5755b3896d66b58eda4da78182b3be43022a14d98702baf1150L413-R420) [[11]](diffhunk://#diff-7985d957fdcde5755b3896d66b58eda4da78182b3be43022a14d98702baf1150L503-R507) [[12]](diffhunk://#diff-7985d957fdcde5755b3896d66b58eda4da78182b3be43022a14d98702baf1150L548-R552) [[13]](diffhunk://#diff-7985d957fdcde5755b3896d66b58eda4da78182b3be43022a14d98702baf1150L734-R738) [[14]](diffhunk://#diff-7985d957fdcde5755b3896d66b58eda4da78182b3be43022a14d98702baf1150L778-R782)
* Adjusted the JSON deserialization logic to handle nullable `mediaMetadata` (`lib/api/library_items/playback_session.g.dart`).

### Updates in provider classes:

* Added logic to handle nullable `mediaMetadata` when creating `bookItem` in `ConnectionNotifier` (`lib/provider/connection_provider.dart`).
* Modified `PlaybackSessionNotifier` to check for nullable `mediaMetadata` before accessing its properties (`lib/provider/session_provider.dart`). [[1]](diffhunk://#diff-9ee4026450de39e5d42a7f68bbcf98db8c3cac97fa60f5df2db83eddf93d38e2L86-R86) [[2]](diffhunk://#diff-9ee4026450de39e5d42a7f68bbcf98db8c3cac97fa60f5df2db83eddf93d38e2L255-R255) [[3]](diffhunk://#diff-9ee4026450de39e5d42a7f68bbcf98db8c3cac97fa60f5df2db83eddf93d38e2L310-R313)